### PR TITLE
About Us Page

### DIFF
--- a/src/components/aboutUsForm.ts
+++ b/src/components/aboutUsForm.ts
@@ -1,0 +1,17 @@
+
+
+export class AboutUsForm {
+  private form: HTMLDivElement;
+
+  
+
+  constructor() {
+    this.form = document.createElement('div');
+   
+  }
+  
+  createForm(): HTMLDivElement {
+    return this.form;
+  }
+
+}

--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -35,7 +35,8 @@ export class Navigation {
     this.list.className = 'header__menu';
     const homeLink = this.addMenuItem('Home', './');
     const catalogLink = this.addMenuItem('Catalog', './products');
-    this.list.append(homeLink, catalogLink);
+    const aboutLink = this.addMenuItem('About us', './about');
+    this.list.append(homeLink, catalogLink, aboutLink);
     this.nav.append(this.list, this.addButtons());
 
     node.append(this.nav);

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -7,6 +7,7 @@ import { BasketPageView } from '../views/basketPageView';
 import { getUserId } from '../state/getUserId';
 import { ProductsView } from '../views/productsView';
 import { ProductView } from '../views/productView';
+import { AboutUsPageView } from '../views/aboutUsPageView';
 
 export class Router {
   homePage = new HomePageView();
@@ -23,6 +24,8 @@ export class Router {
 
   basketPage = new BasketPageView();
 
+  aboutUsPage = new AboutUsPageView();
+
   constructor() {
     this.createView();
   }
@@ -31,7 +34,10 @@ export class Router {
     const rout = this.getUrl();
     if (rout === '/') {
       this.homePage.createView();
-    } else if (rout === '/basket') {
+    } else if (rout === '/about') {
+      this.aboutUsPage.createView();
+    }
+    else if (rout === '/basket') {
       this.basketPage.createView();
     } else if (rout === '/login') {
       if (getUserId()) {

--- a/src/views/aboutUsPageView.ts
+++ b/src/views/aboutUsPageView.ts
@@ -1,0 +1,24 @@
+import { View } from './view';
+import { AboutUsForm} from '../components/aboutUsForm';
+
+export class AboutUsPageView extends View {
+  private aboutUsForm = new AboutUsForm();
+
+  constructor() {
+    super();
+    this.createContent();
+  }
+
+
+  createContent(): void {
+    const sectionAbouyUsForm = this.createSection('about-us-form');
+    sectionAbouyUsForm.append(
+      this.aboutUsForm.createForm()
+    );
+
+
+
+    this.main.append(sectionAbouyUsForm);
+  }
+}
+


### PR DESCRIPTION
## Pull Request Title
About Us Page Implementation

### Description 📝
Add a link to the About Us page in the header navigation. And Implement routing to the About Us page from all other pages. The link navigate to the About Us page to learn more about the development team and the project.

### Changes Made ✨
Clicking on a navigation element directing to the About Us page takes the user to the About Us page.
Navigating to the About Us page changes the URL in the browser.
The About Us page has a unique URL that can be directly accessed.
Directly accessing the About Us page's unique URL leads to the About Us page.
The browser's back and forward buttons work as expected, enabling the user to navigate through their history of visited pages .
The About Us page is accessible regardless of the user's authentication state.
A link to the About Us page is included in the header navigation.
The link is clearly visible and fits the overall design of the website.
Clicking on the icon or link takes the user directly to the About Us page.


### Related Issues 🔗
#109 
#111 

### Reviewers 👀
@Taraikovich @al-pet 


